### PR TITLE
Create a record of processing parameters, fix typo/bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   # NOTE: from pip this installs *python-pdal*, just get from conda
   "pdal >=3.4.5,<4",
   "pystac-client >=0.8.6,<0.9",
+  "pyyaml >=6.0,<7",
   "rioxarray >=0.19.0,<0.20",
   "requests >=2.32.3,<3",
   "scipy >=1.15.2,<2",


### PR DESCRIPTION
Closes #59 

For now, this just dumps the CLI input parameters to a YAML file, and also records processing time and software version:

```yaml
lidar_tools_version: 0.2.0
processing_timestamp: '2025-11-21T10:30:45.123456'
input_parameters:
  geometry: path/to/polygon.geojson
  input: EPT_AWS
  output: /tmp/lidar-tools-output
  src_crs: null
  dst_crs: null
  resolution: 1.0
  dsm_gridding_choice: first_idw
  products: all
  threedep_project: latest
  tile_size: 1.0
  num_process: 1
  overwrite: false
  cleanup: true
  proj_pipeline: null
  filter_noise: true
  height_above_ground_threshold: null
  quiet: false
```